### PR TITLE
fix Config import for HA 2025.11 and newer

### DIFF
--- a/custom_components/swatch/__init__.py
+++ b/custom_components/swatch/__init__.py
@@ -7,7 +7,8 @@ from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_MODEL, CONF_URL
-from homeassistant.core import Config, HomeAssistant
+from homeassistant.core import HomeAssistant
+from homeassistant.core_config import Config
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
     "hacs": "1.6.0",
     "name": "Swatch",
-    "homeassistant": "2021.12.0b2"
+    "homeassistant": "2025.11"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiohttp
 aiohttp_cors==0.7.0
 attr
-homeassistant==2023.6
+homeassistant==2025.11
 atomicwrites==1.4.0
 yarl


### PR DESCRIPTION
There has been a change since newer versions of HA where Config is no longer under homeassistant.core (see for instance https://github.com/agittins/bermuda/issues/346#issuecomment-2453202644 and https://github.com/custom-components/nordpool/pull/433) so the integration was suddenly broken after my latests update.

I've fixed the import and upped the version of HA where this occurs (haven't looked into it much but in the thread it said that it was moved in the 2025.11 beta).